### PR TITLE
Use new screensaver name for required components

### DIFF
--- a/session/xmonad-cinnamon.session
+++ b/session/xmonad-cinnamon.session
@@ -2,5 +2,5 @@
 
 [Cinnamon Session]
 Name=xmonad-cinnamon
-RequiredComponents=xmonad-cinnamon;cinnamon-screensaver;nm-applet;cinnamon-killer-daemon;polkit-gnome-authentication-agent-1;
+RequiredComponents=xmonad-cinnamon;org.cinnamon.ScreenSaver;nm-applet;cinnamon-killer-daemon;polkit-gnome-authentication-agent-1;
 DesktopName=X-Cinnamon


### PR DESCRIPTION
xmonad-cinnamon started failing to start. Found this in the log.

Jun 05 11:57:38 arch1 cinnamon-session[991]: WARNING: t+0.00774s: Unable to find required component 'cinnamon-screensaver'

Upstream https://github.com/linuxmint/Cinnamon they changed the name of the screensaver in required components to org.cinnamon.ScreenSaver

I tested with the new name. It works.